### PR TITLE
[R4R] fix recover byte calculation

### DIFF
--- a/ecdsa/signing/finalize.go
+++ b/ecdsa/signing/finalize.go
@@ -27,6 +27,15 @@ func (round *finalization) Start() *tss.Error {
 		sumS = modN.Add(sumS, round.temp.signRound9SignatureMessage[j].Si)
 	}
 
+	recid := 0
+	// byte v = if(R.X > curve.N) then 2 else 0) | (if R.Y.IsEven then 0 else 1);
+	if round.temp.rx.Cmp(tss.EC().Params().N) > 0 {
+		recid = 2
+	}
+	if round.temp.ry.Bit(0) != 0 {
+		recid |= 1
+	}
+
 	// This is copied from:
 	// https://github.com/btcsuite/btcd/blob/c26ffa870fd817666a857af1bf6498fabba1ffe3/btcec/signature.go#L442-L444
 	// This is needed because of tendermint checks here:
@@ -34,12 +43,14 @@ func (round *finalization) Start() *tss.Error {
 	secp256k1halfN := new(big.Int).Rsh(tss.EC().Params().N, 1)
 	if sumS.Cmp(secp256k1halfN) > 0 {
 		sumS.Sub(tss.EC().Params().N, sumS)
+		recid ^= 1
 	}
 
 	// save the signature for final output
-	round.data.R = round.temp.r
+	round.data.R = round.temp.rx
 	round.data.S = sumS
-	round.data.Signature = append(round.temp.r.Bytes(), sumS.Bytes()...)
+	round.data.SignatureRecovery = byte(recid)
+	round.data.Signature = append(round.temp.rx.Bytes(), sumS.Bytes()...)
 
 	return nil
 }

--- a/ecdsa/signing/local_party.go
+++ b/ecdsa/signing/local_party.go
@@ -72,7 +72,8 @@ type (
 		// round 5
 		li,
 		si,
-		r,
+		rx,
+		ry,
 		roi *big.Int
 		bigR,
 		bigAi,
@@ -89,10 +90,11 @@ type (
 	}
 
 	LocalPartySignData struct {
-		Transaction []byte
-		Signature   []byte
-		R           *big.Int
-		S           *big.Int
+		Transaction       []byte
+		Signature         []byte
+		SignatureRecovery byte
+		R                 *big.Int
+		S                 *big.Int
 	}
 )
 

--- a/ecdsa/signing/local_party_test.go
+++ b/ecdsa/signing/local_party_test.go
@@ -97,7 +97,7 @@ signing:
 			if atomic.LoadInt32(&ended) == int32(len(signPIDs)) {
 				t.Logf("Done. Received save data from %d participants", ended)
 				R := parties[0].temp.bigR
-				r := parties[0].temp.r
+				r := parties[0].temp.rx
 				fmt.Printf("sign result: R(%s, %s), r=%s\n", R.X().String(), R.Y().String(), r.String())
 
 				modN := common.ModInt(tss.EC().Params().N)

--- a/ecdsa/signing/round_5.go
+++ b/ecdsa/signing/round_5.go
@@ -48,8 +48,9 @@ func (round *round5) Start() *tss.Error {
 	R = R.ScalarMult(round.temp.thelta_inverse)
 	N := tss.EC().Params().N
 	modN := common.ModInt(N)
-	r := R.X()
-	si := modN.Add(modN.Mul(round.temp.m, round.temp.k), modN.Mul(r, round.temp.sigma))
+	rx := R.X()
+	ry := R.Y()
+	si := modN.Add(modN.Mul(round.temp.m, round.temp.k), modN.Mul(rx, round.temp.sigma))
 	// TODO: clear temp.k, temp.w
 
 	li := random.GetRandomPositiveInt(N)  // li
@@ -73,7 +74,8 @@ func (round *round5) Start() *tss.Error {
 	round.temp.roi = roI
 	round.temp.DPower = cmt.D
 	round.temp.si = si
-	round.temp.r = r
+	round.temp.rx = rx
+	round.temp.ry = ry
 	round.temp.bigR = R
 
 	return nil

--- a/ecdsa/signing/round_7.go
+++ b/ecdsa/signing/round_7.go
@@ -58,7 +58,7 @@ func (round *round7) Start() *tss.Error {
 	AX, AY := round.temp.bigAi.X(), round.temp.bigAi.Y()
 	minusM := modN.Sub(big.NewInt(0), round.temp.m)
 	gToMInvX, gToMInvY := tss.EC().ScalarBaseMult(minusM.Bytes())
-	minusR := modN.Sub(big.NewInt(0), round.temp.r)
+	minusR := modN.Sub(big.NewInt(0), round.temp.rx)
 	yToRInvX, yToRInvY := tss.EC().ScalarMult(round.key.ECDSAPub.X(), round.key.ECDSAPub.Y(), minusR.Bytes())
 	VX, VY := tss.EC().Add(gToMInvX, gToMInvY, yToRInvX, yToRInvY)
 	VX, VY = tss.EC().Add(VX, VY, round.temp.bigVi.X(), round.temp.bigVi.Y())


### PR DESCRIPTION
high level description about the recover byte:
https://bitcoin.stackexchange.com/questions/38351/ecdsa-v-r-s-what-is-v
spec: http://www.secg.org/sec1-v2.pdf Section 4.1.6

This is ethereum refered (btcec) calculate recover byte: https://sourcegraph.com/github.com/ethereum/go-ethereum@HEAD/-/blob/vendor/github.com/btcsuite/btcd/btcec/signature.go#L345
It try different byte and see whether the signature can recover correct pubkey


This is how esdsa determine recover byte (I am going to borrow how “recid” is calculated there):
https://github.com/bitcoin-core/secp256k1/blob/e541a90ef6461007d9c6a74b9f9a7fb8aa34aaa8/src/ecdsa_impl.h#L277-L317
