### PR TITLE
fix msg in eddsa hasn't to be a int.

### DIFF
--- a/eddsa/resharing/local_party_test.go
+++ b/eddsa/resharing/local_party_test.go
@@ -164,7 +164,7 @@ signing:
 
 	for j, signPID := range signPIDs {
 		params := tss.NewParameters(signP2pCtx, signPID, len(signPIDs), newThreshold)
-		P := signing.NewLocalParty(big.NewInt(42), params, signKeys[j], signOutCh, signEndCh).(*signing.LocalParty)
+		P := signing.NewLocalParty(big.NewInt(42).Bytes(), params, signKeys[j], signOutCh, signEndCh).(*signing.LocalParty)
 		signParties = append(signParties, P)
 		go func(P *signing.LocalParty) {
 			if err := P.Start(); err != nil {

--- a/eddsa/signing/finalize.go
+++ b/eddsa/signing/finalize.go
@@ -43,7 +43,7 @@ func (round *finalization) Start() *tss.Error {
 	round.data.Signature = append(bigIntToEncodedBytes(round.temp.r)[:], sumS[:]...)
 	round.data.R = round.temp.r.Bytes()
 	round.data.S = s.Bytes()
-	round.data.M = round.temp.m.Bytes()
+	round.data.M = round.temp.m
 
 	pk := edwards.PublicKey{
 		Curve: tss.EC(),
@@ -51,7 +51,7 @@ func (round *finalization) Start() *tss.Error {
 		Y:     round.key.EDDSAPub.Y(),
 	}
 
-	ok := edwards.Verify(&pk, round.temp.m.Bytes(), round.temp.r, s)
+	ok := edwards.Verify(&pk, round.temp.m, round.temp.r, s)
 	if !ok {
 		return round.WrapError(fmt.Errorf("signature verification failed"))
 	}

--- a/eddsa/signing/local_party.go
+++ b/eddsa/signing/local_party.go
@@ -48,8 +48,8 @@ type (
 
 		// temp data (thrown away after sign) / round 1
 		wi,
-		m,
 		ri *big.Int
+		m        []byte
 		pointRi  *crypto.ECPoint
 		deCommit cmt.HashDeCommitment
 
@@ -63,7 +63,7 @@ type (
 )
 
 func NewLocalParty(
-	msg *big.Int,
+	msg []byte,
 	params *tss.Parameters,
 	key keygen.LocalPartySaveData,
 	out chan<- tss.Message,

--- a/eddsa/signing/local_party_test.go
+++ b/eddsa/signing/local_party_test.go
@@ -58,7 +58,7 @@ func TestE2EConcurrent(t *testing.T) {
 
 	updater := test.SharedPartyUpdater
 
-	msg := big.NewInt(200)
+	msg := big.NewInt(200).Bytes()
 	// init the parties
 	for i := 0; i < len(signPIDs); i++ {
 		params := tss.NewParameters(p2pCtx, signPIDs[i], len(signPIDs), threshold)
@@ -131,7 +131,7 @@ signing:
 					println("new sig error, ", err.Error())
 				}
 
-				ok := edwards.Verify(&pk, msg.Bytes(), newSig.R, newSig.S)
+				ok := edwards.Verify(&pk, msg, newSig.R, newSig.S)
 				assert.True(t, ok, "eddsa verify must pass")
 				t.Log("EDDSA signing test done.")
 				// END EDDSA verify

--- a/eddsa/signing/round_3.go
+++ b/eddsa/signing/round_3.go
@@ -77,7 +77,7 @@ func (round *round3) Start() *tss.Error {
 	h.Reset()
 	h.Write(encodedR[:])
 	h.Write(encodedPubKey[:])
-	h.Write(round.temp.m.Bytes())
+	h.Write(round.temp.m)
 
 	var lambda [64]byte
 	h.Sum(lambda[:0])


### PR DESCRIPTION
successful XLM transfers： https://stellarchain.io/address/GBDAGK6PRANMCIXP4TE2L2M4Q7CDUR77WS6XA5TQXADQKTUNHUZBCRCC