### PR TITLE
Improve DLN proof verification performance for large signing groups

### DIFF
--- a/ecdsa/keygen/dln_verifier.go
+++ b/ecdsa/keygen/dln_verifier.go
@@ -10,10 +10,17 @@ import (
 	"errors"
 	"math/big"
 	"runtime"
+
+	"github.com/bnb-chain/tss-lib/crypto/dlnproof"
 )
 
 type DlnProofVerifier struct {
 	semaphore chan interface{}
+}
+
+type message interface {
+	UnmarshalDLNProof1() (*dlnproof.Proof, error)
+	UnmarshalDLNProof2() (*dlnproof.Proof, error)
 }
 
 func NewDlnProofVerifier(optionalConcurrency ...int) *DlnProofVerifier {
@@ -35,7 +42,7 @@ func NewDlnProofVerifier(optionalConcurrency ...int) *DlnProofVerifier {
 }
 
 func (dpv *DlnProofVerifier) VerifyDLNProof1(
-	r1msg *KGRound1Message,
+	m message,
 	h1, h2, n *big.Int,
 	onDone func(bool),
 ) {
@@ -43,7 +50,7 @@ func (dpv *DlnProofVerifier) VerifyDLNProof1(
 	go func() {
 		defer func() { <-dpv.semaphore }()
 
-		dlnProof, err := r1msg.UnmarshalDLNProof1()
+		dlnProof, err := m.UnmarshalDLNProof1()
 		if err != nil {
 			onDone(false)
 			return
@@ -54,7 +61,7 @@ func (dpv *DlnProofVerifier) VerifyDLNProof1(
 }
 
 func (dpv *DlnProofVerifier) VerifyDLNProof2(
-	r1msg *KGRound1Message,
+	m message,
 	h1, h2, n *big.Int,
 	onDone func(bool),
 ) {
@@ -62,7 +69,7 @@ func (dpv *DlnProofVerifier) VerifyDLNProof2(
 	go func() {
 		defer func() { <-dpv.semaphore }()
 
-		dlnProof, err := r1msg.UnmarshalDLNProof2()
+		dlnProof, err := m.UnmarshalDLNProof2()
 		if err != nil {
 			onDone(false)
 			return

--- a/ecdsa/keygen/dln_verifier.go
+++ b/ecdsa/keygen/dln_verifier.go
@@ -7,6 +7,7 @@
 package keygen
 
 import (
+	"errors"
 	"math/big"
 
 	"github.com/bnb-chain/tss-lib/crypto/dlnproof"
@@ -22,6 +23,10 @@ type message interface {
 }
 
 func NewDlnProofVerifier(concurrency int) *DlnProofVerifier {
+	if concurrency == 0 {
+		panic(errors.New("NewDlnProofverifier: concurrency level must not be zero"))
+	}
+
 	semaphore := make(chan interface{}, concurrency)
 
 	return &DlnProofVerifier{

--- a/ecdsa/keygen/dln_verifier.go
+++ b/ecdsa/keygen/dln_verifier.go
@@ -7,9 +7,7 @@
 package keygen
 
 import (
-	"errors"
 	"math/big"
-	"runtime"
 
 	"github.com/bnb-chain/tss-lib/crypto/dlnproof"
 )
@@ -23,17 +21,7 @@ type message interface {
 	UnmarshalDLNProof2() (*dlnproof.Proof, error)
 }
 
-func NewDlnProofVerifier(optionalConcurrency ...int) *DlnProofVerifier {
-	var concurrency int
-	if 0 < len(optionalConcurrency) {
-		if 1 < len(optionalConcurrency) {
-			panic(errors.New("NewDlnProofVerifier: expected 0 or 1 item in `optionalConcurrency`"))
-		}
-		concurrency = optionalConcurrency[0]
-	} else {
-		concurrency = runtime.NumCPU()
-	}
-
+func NewDlnProofVerifier(concurrency int) *DlnProofVerifier {
 	semaphore := make(chan interface{}, concurrency)
 
 	return &DlnProofVerifier{

--- a/ecdsa/keygen/dln_verifier.go
+++ b/ecdsa/keygen/dln_verifier.go
@@ -1,0 +1,73 @@
+// Copyright © 2019 Binance
+//
+// This file is part of Binance. The full Binance copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+package keygen
+
+import (
+	"errors"
+	"math/big"
+	"runtime"
+)
+
+type DlnProofVerifier struct {
+	semaphore chan interface{}
+}
+
+func NewDlnProofVerifier(optionalConcurrency ...int) *DlnProofVerifier {
+	var concurrency int
+	if 0 < len(optionalConcurrency) {
+		if 1 < len(optionalConcurrency) {
+			panic(errors.New("NewDlnProofVerifier: expected 0 or 1 item in `optionalConcurrency`"))
+		}
+		concurrency = optionalConcurrency[0]
+	} else {
+		concurrency = runtime.NumCPU()
+	}
+
+	semaphore := make(chan interface{}, concurrency)
+
+	return &DlnProofVerifier{
+		semaphore: semaphore,
+	}
+}
+
+func (dpv *DlnProofVerifier) VerifyDLNProof1(
+	r1msg *KGRound1Message,
+	h1, h2, n *big.Int,
+	onDone func(bool),
+) {
+	dpv.semaphore <- struct{}{}
+	go func() {
+		defer func() { <-dpv.semaphore }()
+
+		dlnProof, err := r1msg.UnmarshalDLNProof1()
+		if err != nil {
+			onDone(false)
+			return
+		}
+
+		onDone(dlnProof.Verify(h1, h2, n))
+	}()
+}
+
+func (dpv *DlnProofVerifier) VerifyDLNProof2(
+	r1msg *KGRound1Message,
+	h1, h2, n *big.Int,
+	onDone func(bool),
+) {
+	dpv.semaphore <- struct{}{}
+	go func() {
+		defer func() { <-dpv.semaphore }()
+
+		dlnProof, err := r1msg.UnmarshalDLNProof2()
+		if err != nil {
+			onDone(false)
+			return
+		}
+
+		onDone(dlnProof.Verify(h1, h2, n))
+	}()
+}

--- a/ecdsa/keygen/dln_verifier_test.go
+++ b/ecdsa/keygen/dln_verifier_test.go
@@ -7,6 +7,7 @@
 package keygen
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/bnb-chain/tss-lib/crypto/dlnproof"
@@ -33,4 +34,163 @@ func BenchmarkDLNProofVerification(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		proof.Verify(params.H1i, params.H2i, params.NTildei)
 	}
+}
+
+func TestVerifyDLNProof1_Success(t *testing.T) {
+	preParams, proof := prepareProof(t)
+	message := &KGRound1Message{
+		Dlnproof_1: proof,
+	}
+
+	verifier := NewDlnProofVerifier()
+
+	resultChan := make(chan bool)
+
+	verifier.VerifyDLNProof1(message, preParams.H1i, preParams.H2i, preParams.NTildei, func(result bool) {
+		resultChan <- result
+	})
+
+	success := <-resultChan
+	if !success {
+		t.Fatal("expected positive verification")
+	}
+}
+
+func TestVerifyDLNProof1_MalformedMessage(t *testing.T) {
+	preParams, proof := prepareProof(t)
+	message := &KGRound1Message{
+		Dlnproof_1: proof[:len(proof)-1], // truncate
+	}
+
+	verifier := NewDlnProofVerifier()
+
+	resultChan := make(chan bool)
+
+	verifier.VerifyDLNProof1(message, preParams.H1i, preParams.H2i, preParams.NTildei, func(result bool) {
+		resultChan <- result
+	})
+
+	success := <-resultChan
+	if success {
+		t.Fatal("expected negative verification")
+	}
+}
+
+func TestVerifyDLNProof1_IncorrectProof(t *testing.T) {
+	preParams, proof := prepareProof(t)
+	message := &KGRound1Message{
+		Dlnproof_1: proof,
+	}
+
+	verifier := NewDlnProofVerifier()
+
+	resultChan := make(chan bool)
+
+	wrongH1i := preParams.H1i.Sub(preParams.H1i, big.NewInt(1))
+	verifier.VerifyDLNProof1(message, wrongH1i, preParams.H2i, preParams.NTildei, func(result bool) {
+		resultChan <- result
+	})
+
+	success := <-resultChan
+	if success {
+		t.Fatal("expected negative verification")
+	}
+}
+
+func TestVerifyDLNProof2_Success(t *testing.T) {
+	preParams, proof := prepareProof(t)
+	message := &KGRound1Message{
+		Dlnproof_2: proof,
+	}
+
+	verifier := NewDlnProofVerifier()
+
+	resultChan := make(chan bool)
+
+	verifier.VerifyDLNProof2(message, preParams.H1i, preParams.H2i, preParams.NTildei, func(result bool) {
+		resultChan <- result
+	})
+
+	success := <-resultChan
+	if !success {
+		t.Fatal("expected positive verification")
+	}
+}
+
+func TestVerifyDLNProof2_MalformedMessage(t *testing.T) {
+	preParams, proof := prepareProof(t)
+	message := &KGRound1Message{
+		Dlnproof_2: proof[:len(proof)-1], // truncate
+	}
+
+	verifier := NewDlnProofVerifier()
+
+	resultChan := make(chan bool)
+
+	verifier.VerifyDLNProof2(message, preParams.H1i, preParams.H2i, preParams.NTildei, func(result bool) {
+		resultChan <- result
+	})
+
+	success := <-resultChan
+	if success {
+		t.Fatal("expected negative verification")
+	}
+}
+
+func TestVerifyDLNProof2_IncorrectProof(t *testing.T) {
+	preParams, proof := prepareProof(t)
+	message := &KGRound1Message{
+		Dlnproof_2: proof,
+	}
+
+	verifier := NewDlnProofVerifier()
+
+	resultChan := make(chan bool)
+
+	wrongH2i := preParams.H2i.Add(preParams.H2i, big.NewInt(1))
+	verifier.VerifyDLNProof2(message, preParams.H1i, wrongH2i, preParams.NTildei, func(result bool) {
+		resultChan <- result
+	})
+
+	success := <-resultChan
+	if success {
+		t.Fatal("expected negative verification")
+	}
+}
+
+// TestOptionalConcurrency check that if the concurrency level optional flag
+// is set, it is taken into account.
+func TestOptionalConcurrency(t *testing.T) {
+	concurrency := 7161
+
+	verifier := NewDlnProofVerifier(concurrency)
+
+	if cap(verifier.semaphore) != concurrency {
+		t.Fatal("unexpected concurrency level")
+	}
+}
+
+func prepareProof(t *testing.T) (*LocalPreParams, [][]byte) {
+	localPartySaveData, _, err := LoadKeygenTestFixtures(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	preParams := localPartySaveData[0].LocalPreParams
+
+	proof := dlnproof.NewDLNProof(
+		preParams.H1i,
+		preParams.H2i,
+		preParams.Alpha,
+		preParams.P,
+		preParams.Q,
+		preParams.NTildei,
+	)
+
+	serialized, err := proof.Serialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &preParams, serialized
 }

--- a/ecdsa/keygen/dln_verifier_test.go
+++ b/ecdsa/keygen/dln_verifier_test.go
@@ -1,0 +1,36 @@
+// Copyright © 2019 Binance
+//
+// This file is part of Binance. The full Binance copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+package keygen
+
+import (
+	"testing"
+
+	"github.com/bnb-chain/tss-lib/crypto/dlnproof"
+)
+
+func BenchmarkDLNProofVerification(b *testing.B) {
+	localPartySaveData, _, err := LoadKeygenTestFixtures(1)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	params := localPartySaveData[0].LocalPreParams
+
+	proof := dlnproof.NewDLNProof(
+		params.H1i,
+		params.H2i,
+		params.Alpha,
+		params.P,
+		params.Q,
+		params.NTildei,
+	)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		proof.Verify(params.H1i, params.H2i, params.NTildei)
+	}
+}

--- a/ecdsa/keygen/dln_verifier_test.go
+++ b/ecdsa/keygen/dln_verifier_test.go
@@ -8,6 +8,7 @@ package keygen
 
 import (
 	"math/big"
+	"runtime"
 	"testing"
 
 	"github.com/bnb-chain/tss-lib/crypto/dlnproof"
@@ -42,7 +43,7 @@ func BenchmarkDlnVerifier_VerifyProof1(b *testing.B) {
 		Dlnproof_1: proof,
 	}
 
-	verifier := NewDlnProofVerifier()
+	verifier := NewDlnProofVerifier(runtime.GOMAXPROCS(0))
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -60,7 +61,7 @@ func BenchmarkDlnVerifier_VerifyProof2(b *testing.B) {
 		Dlnproof_2: proof,
 	}
 
-	verifier := NewDlnProofVerifier()
+	verifier := NewDlnProofVerifier(runtime.GOMAXPROCS(0))
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -78,7 +79,7 @@ func TestVerifyDLNProof1_Success(t *testing.T) {
 		Dlnproof_1: proof,
 	}
 
-	verifier := NewDlnProofVerifier()
+	verifier := NewDlnProofVerifier(runtime.GOMAXPROCS(0))
 
 	resultChan := make(chan bool)
 
@@ -98,7 +99,7 @@ func TestVerifyDLNProof1_MalformedMessage(t *testing.T) {
 		Dlnproof_1: proof[:len(proof)-1], // truncate
 	}
 
-	verifier := NewDlnProofVerifier()
+	verifier := NewDlnProofVerifier(runtime.GOMAXPROCS(0))
 
 	resultChan := make(chan bool)
 
@@ -118,7 +119,7 @@ func TestVerifyDLNProof1_IncorrectProof(t *testing.T) {
 		Dlnproof_1: proof,
 	}
 
-	verifier := NewDlnProofVerifier()
+	verifier := NewDlnProofVerifier(runtime.GOMAXPROCS(0))
 
 	resultChan := make(chan bool)
 
@@ -139,7 +140,7 @@ func TestVerifyDLNProof2_Success(t *testing.T) {
 		Dlnproof_2: proof,
 	}
 
-	verifier := NewDlnProofVerifier()
+	verifier := NewDlnProofVerifier(runtime.GOMAXPROCS(0))
 
 	resultChan := make(chan bool)
 
@@ -159,7 +160,7 @@ func TestVerifyDLNProof2_MalformedMessage(t *testing.T) {
 		Dlnproof_2: proof[:len(proof)-1], // truncate
 	}
 
-	verifier := NewDlnProofVerifier()
+	verifier := NewDlnProofVerifier(runtime.GOMAXPROCS(0))
 
 	resultChan := make(chan bool)
 
@@ -179,7 +180,7 @@ func TestVerifyDLNProof2_IncorrectProof(t *testing.T) {
 		Dlnproof_2: proof,
 	}
 
-	verifier := NewDlnProofVerifier()
+	verifier := NewDlnProofVerifier(runtime.GOMAXPROCS(0))
 
 	resultChan := make(chan bool)
 
@@ -191,18 +192,6 @@ func TestVerifyDLNProof2_IncorrectProof(t *testing.T) {
 	success := <-resultChan
 	if success {
 		t.Fatal("expected negative verification")
-	}
-}
-
-// TestOptionalConcurrency check that if the concurrency level optional flag
-// is set, it is taken into account.
-func TestOptionalConcurrency(t *testing.T) {
-	concurrency := 7161
-
-	verifier := NewDlnProofVerifier(concurrency)
-
-	if cap(verifier.semaphore) != concurrency {
-		t.Fatal("unexpected concurrency level")
 	}
 }
 

--- a/ecdsa/keygen/round_1.go
+++ b/ecdsa/keygen/round_1.go
@@ -74,7 +74,7 @@ func (round *round1) Start() *tss.Error {
 	} else if round.save.LocalPreParams.ValidateWithProof() {
 		preParams = &round.save.LocalPreParams
 	} else {
-		preParams, err = GeneratePreParams(round.SafePrimeGenTimeout(), 3)
+		preParams, err = GeneratePreParams(round.SafePrimeGenTimeout(), round.Concurrency())
 		if err != nil {
 			return round.WrapError(errors.New("pre-params generation failed"), Pi)
 		}

--- a/ecdsa/keygen/round_2.go
+++ b/ecdsa/keygen/round_2.go
@@ -64,14 +64,14 @@ func (round *round2) Start() *tss.Error {
 		_j := j
 		_msg := msg
 
-		dlnVerifier.VerifyDLNProof1(r1msg, H1j, H2j, NTildej, func(valid bool) {
-			if !valid {
+		dlnVerifier.VerifyDLNProof1(r1msg, H1j, H2j, NTildej, func(isValid bool) {
+			if !isValid {
 				dlnProof1FailCulprits[_j] = _msg.GetFrom()
 			}
 			wg.Done()
 		})
-		dlnVerifier.VerifyDLNProof2(r1msg, H2j, H1j, NTildej, func(valid bool) {
-			if !valid {
+		dlnVerifier.VerifyDLNProof2(r1msg, H2j, H1j, NTildej, func(isValid bool) {
+			if !isValid {
 				dlnProof2FailCulprits[_j] = _msg.GetFrom()
 			}
 			wg.Done()

--- a/ecdsa/keygen/round_2.go
+++ b/ecdsa/keygen/round_2.go
@@ -9,7 +9,6 @@ package keygen
 import (
 	"encoding/hex"
 	"errors"
-	"math/big"
 	"sync"
 
 	"github.com/bnb-chain/tss-lib/tss"
@@ -26,6 +25,8 @@ func (round *round2) Start() *tss.Error {
 	round.number = 2
 	round.started = true
 	round.resetOK()
+
+	dlnVerifier := NewDlnProofVerifier()
 
 	i := round.PartyID().Index
 
@@ -58,19 +59,23 @@ func (round *round2) Start() *tss.Error {
 			return round.WrapError(errors.New("this h2j was already used by another party"), msg.GetFrom())
 		}
 		h1H2Map[h1JHex], h1H2Map[h2JHex] = struct{}{}, struct{}{}
+
 		wg.Add(2)
-		go func(j int, msg tss.ParsedMessage, r1msg *KGRound1Message, H1j, H2j, NTildej *big.Int) {
-			if dlnProof1, err := r1msg.UnmarshalDLNProof1(); err != nil || !dlnProof1.Verify(H1j, H2j, NTildej) {
-				dlnProof1FailCulprits[j] = msg.GetFrom()
+		_j := j
+		_msg := msg
+
+		dlnVerifier.VerifyDLNProof1(r1msg, H1j, H2j, NTildej, func(valid bool) {
+			if !valid {
+				dlnProof1FailCulprits[_j] = _msg.GetFrom()
 			}
 			wg.Done()
-		}(j, msg, r1msg, H1j, H2j, NTildej)
-		go func(j int, msg tss.ParsedMessage, r1msg *KGRound1Message, H1j, H2j, NTildej *big.Int) {
-			if dlnProof2, err := r1msg.UnmarshalDLNProof2(); err != nil || !dlnProof2.Verify(H2j, H1j, NTildej) {
-				dlnProof2FailCulprits[j] = msg.GetFrom()
+		})
+		dlnVerifier.VerifyDLNProof2(r1msg, H2j, H1j, NTildej, func(valid bool) {
+			if !valid {
+				dlnProof2FailCulprits[_j] = _msg.GetFrom()
 			}
 			wg.Done()
-		}(j, msg, r1msg, H1j, H2j, NTildej)
+		})
 	}
 	wg.Wait()
 	for _, culprit := range append(dlnProof1FailCulprits, dlnProof2FailCulprits...) {

--- a/ecdsa/keygen/round_2.go
+++ b/ecdsa/keygen/round_2.go
@@ -26,7 +26,7 @@ func (round *round2) Start() *tss.Error {
 	round.started = true
 	round.resetOK()
 
-	dlnVerifier := NewDlnProofVerifier()
+	dlnVerifier := NewDlnProofVerifier(round.Concurrency())
 
 	i := round.PartyID().Index
 

--- a/ecdsa/keygen/round_2.go
+++ b/ecdsa/keygen/round_2.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/bnb-chain/tss-lib/common"
 	"github.com/bnb-chain/tss-lib/tss"
 )
 
@@ -26,6 +27,11 @@ func (round *round2) Start() *tss.Error {
 	round.started = true
 	round.resetOK()
 
+	common.Logger.Debugf(
+		"%s Setting up DLN verification with concurrency level of %d",
+		round.PartyID(),
+		round.Concurrency(),
+	)
 	dlnVerifier := NewDlnProofVerifier(round.Concurrency())
 
 	i := round.PartyID().Index

--- a/ecdsa/resharing/round_2_new_step_1.go
+++ b/ecdsa/resharing/round_2_new_step_1.go
@@ -49,7 +49,7 @@ func (round *round2) Start() *tss.Error {
 		preParams = &round.save.LocalPreParams
 	} else {
 		var err error
-		preParams, err = keygen.GeneratePreParams(round.SafePrimeGenTimeout())
+		preParams, err = keygen.GeneratePreParams(round.SafePrimeGenTimeout(), round.Concurrency())
 		if err != nil {
 			return round.WrapError(errors.New("pre-params generation failed"), Pi)
 		}

--- a/ecdsa/resharing/round_4_new_step_2.go
+++ b/ecdsa/resharing/round_4_new_step_2.go
@@ -37,6 +37,11 @@ func (round *round4) Start() *tss.Error {
 		return nil
 	}
 
+	common.Logger.Debugf(
+		"%s Setting up DLN verification with concurrency level of %d",
+		round.PartyID(),
+		round.Concurrency(),
+	)
 	dlnVerifier := keygen.NewDlnProofVerifier(round.Concurrency())
 
 	Pi := round.PartyID()

--- a/ecdsa/resharing/round_4_new_step_2.go
+++ b/ecdsa/resharing/round_4_new_step_2.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bnb-chain/tss-lib/crypto"
 	"github.com/bnb-chain/tss-lib/crypto/commitments"
 	"github.com/bnb-chain/tss-lib/crypto/vss"
+	"github.com/bnb-chain/tss-lib/ecdsa/keygen"
 	"github.com/bnb-chain/tss-lib/tss"
 )
 
@@ -35,6 +36,8 @@ func (round *round4) Start() *tss.Error {
 		// both committees proceed to round 5 after receiving "ACK" messages from the new committee
 		return nil
 	}
+
+	dlnVerifier := keygen.NewDlnProofVerifier(round.Concurrency())
 
 	Pi := round.PartyID()
 	i := Pi.Index
@@ -71,20 +74,22 @@ func (round *round4) Start() *tss.Error {
 			}
 			wg.Done()
 		}(j, msg, r2msg1)
-		go func(j int, msg tss.ParsedMessage, r2msg1 *DGRound2Message1, H1j, H2j, NTildej *big.Int) {
-			if dlnProof1, err := r2msg1.UnmarshalDLNProof1(); err != nil || !dlnProof1.Verify(H1j, H2j, NTildej) {
-				dlnProof1FailCulprits[j] = msg.GetFrom()
-				common.Logger.Warningf("dln proof 1 verify failed for party %s", msg.GetFrom(), err)
+		_j := j
+		_msg := msg
+		dlnVerifier.VerifyDLNProof1(r2msg1, H1j, H2j, NTildej, func(isValid bool) {
+			if !isValid {
+				dlnProof1FailCulprits[_j] = _msg.GetFrom()
+				common.Logger.Warningf("dln proof 1 verify failed for party %s", _msg.GetFrom())
 			}
 			wg.Done()
-		}(j, msg, r2msg1, H1j, H2j, NTildej)
-		go func(j int, msg tss.ParsedMessage, r2msg1 *DGRound2Message1, H1j, H2j, NTildej *big.Int) {
-			if dlnProof2, err := r2msg1.UnmarshalDLNProof2(); err != nil || !dlnProof2.Verify(H2j, H1j, NTildej) {
-				dlnProof2FailCulprits[j] = msg.GetFrom()
-				common.Logger.Warningf("dln proof 2 verify failed for party %s", msg.GetFrom(), err)
+		})
+		dlnVerifier.VerifyDLNProof2(r2msg1, H2j, H1j, NTildej, func(isValid bool) {
+			if !isValid {
+				dlnProof2FailCulprits[_j] = _msg.GetFrom()
+				common.Logger.Warningf("dln proof 2 verify failed for party %s", _msg.GetFrom())
 			}
 			wg.Done()
-		}(j, msg, r2msg1, H1j, H2j, NTildej)
+		})
 	}
 	wg.Wait()
 	for _, culprit := range append(append(paiProofCulprits, dlnProof1FailCulprits...), dlnProof2FailCulprits...) {

--- a/tss/params.go
+++ b/tss/params.go
@@ -8,7 +8,7 @@ package tss
 
 import (
 	"crypto/elliptic"
-	"errors"
+	"runtime"
 	"time"
 )
 
@@ -19,6 +19,7 @@ type (
 		parties             *PeerContext
 		partyCount          int
 		threshold           int
+		concurrency         int
 		safePrimeGenTimeout time.Duration
 	}
 
@@ -35,23 +36,15 @@ const (
 )
 
 // Exported, used in `tss` client
-func NewParameters(ec elliptic.Curve, ctx *PeerContext, partyID *PartyID, partyCount, threshold int, optionalSafePrimeGenTimeout ...time.Duration) *Parameters {
-	var safePrimeGenTimeout time.Duration
-	if 0 < len(optionalSafePrimeGenTimeout) {
-		if 1 < len(optionalSafePrimeGenTimeout) {
-			panic(errors.New("GeneratePreParams: expected 0 or 1 item in `optionalSafePrimeGenTimeout`"))
-		}
-		safePrimeGenTimeout = optionalSafePrimeGenTimeout[0]
-	} else {
-		safePrimeGenTimeout = defaultSafePrimeGenTimeout
-	}
+func NewParameters(ec elliptic.Curve, ctx *PeerContext, partyID *PartyID, partyCount, threshold int) *Parameters {
 	return &Parameters{
 		ec:                  ec,
 		parties:             ctx,
 		partyID:             partyID,
 		partyCount:          partyCount,
 		threshold:           threshold,
-		safePrimeGenTimeout: safePrimeGenTimeout,
+		concurrency:         runtime.GOMAXPROCS(0),
+		safePrimeGenTimeout: defaultSafePrimeGenTimeout,
 	}
 }
 
@@ -75,8 +68,20 @@ func (params *Parameters) Threshold() int {
 	return params.threshold
 }
 
+func (params *Parameters) Concurrency() int {
+	return params.concurrency
+}
+
 func (params *Parameters) SafePrimeGenTimeout() time.Duration {
 	return params.safePrimeGenTimeout
+}
+
+func (params *Parameters) SetConcurrency(concurrency int) {
+	params.concurrency = concurrency
+}
+
+func (params *Parameters) SetSafePrimeGenTimeout(timeout time.Duration) {
+	params.safePrimeGenTimeout = timeout
 }
 
 // ----- //

--- a/tss/params.go
+++ b/tss/params.go
@@ -76,6 +76,7 @@ func (params *Parameters) SafePrimeGenTimeout() time.Duration {
 	return params.safePrimeGenTimeout
 }
 
+// The concurrency level must be >= 1.
 func (params *Parameters) SetConcurrency(concurrency int) {
 	params.concurrency = concurrency
 }


### PR DESCRIPTION
Verification of discrete logarithm proofs is the most expensive part of threshold ECDSA key generation for large groups. In round 2 of key generation, the local party needs to verify proofs received from all other parties. The cost of a call to `dlnProof.Verify` measured on Darwin/arm64 Apple M1 max is 341758528 ns/op - see `BenchmarkDlnProof_Verify`. There are two proofs that need to be verified during the key generation so assuming there are two cores available exclusively for this work, the verification of 100 messages takes about 35 seconds. For a group size of 1000, the verification takes about 350 seconds. The verification is performed in separate goroutines with no control over the number of goroutines created. When executing the protocol locally, during the development, for a group size of 100, `100*99*2 = 19 800` goroutines for DLN proof verification are created more or less at the same time. Even such a powerful CPU as Apple M1 Max struggles with computing the proofs - it takes more than 16 minutes on all available cores and all other processes are starved.

To optimize the code to allow it to be executed for larger groups, the number of goroutines created at the same time for DLN proof verification is throttled so that all other processes are not perpetually denied necessary CPU time to perform their work. This is achieved by introducing the `DlnProofVerifier` that limits the concurrency level, by default to the number of CPUs (cores) available.

The throttling logic has no real impact on the DLN proof verification performance for small groups:
```
BenchmarkDlnProof_Verify-10    	           3	 343508611 ns/op	 1777336 B/op	  3803 allocs/op
BenchmarkDlnVerifier_VerifyProof1-10       3	 343131722 ns/op	 1857218 B/op	  4319 allocs/op
BenchmarkDlnVerifier_VerifyProof2-10       3	 342200917 ns/op	 1858941 B/op	  4319 allocs/op
```

Here is a two-minute profiling sample when executing locally key generation for a group size of 100 on the `master` branch:

![image](https://user-images.githubusercontent.com/4712360/186272240-029fc26f-ad75-4b64-920b-67314fbce00a.png)