### PR TITLE
[nit] remove unnecessary cmp

### DIFF
--- a/common/random.go
+++ b/common/random.go
@@ -42,7 +42,7 @@ func GetRandomPositiveInt(lessThan *big.Int) *big.Int {
 	var try *big.Int
 	for {
 		try = MustGetRandomInt(lessThan.BitLen())
-		if try.Cmp(lessThan) < 0 && try.Cmp(zero) >= 0 {
+		if try.Cmp(lessThan) < 0 {
 			break
 		}
 	}


### PR DESCRIPTION
`MustGetRandomInt`(which calls `rand.Int`) always returns a non-negative big int, so there's no need to check against zero at the caller side.

```golang
func rand.Int(rand io.Reader, max *big.Int) (n *big.Int, err error)
Int returns a uniform random value in [0, max). It panics if max <= 0.
```