### PR TITLE
[nit] remove unnecessary assignment

### DIFF
--- a/crypto/vss/feldman_vss.go
+++ b/crypto/vss/feldman_vss.go
@@ -78,7 +78,6 @@ func Create(ec elliptic.Curve, threshold int, secret *big.Int, indexes []*big.In
 	}
 
 	poly := samplePolynomial(ec, threshold, secret)
-	poly[0] = secret // becomes sigma*G in v
 	v := make(Vs, len(poly))
 	for i, ai := range poly {
 		v[i] = crypto.ScalarBaseMult(ec, ai)


### PR DESCRIPTION
`samplePolynomial` has already assigned `secret` to the `0` index, so no need to assign again.