### PR TITLE
oldok init prevents from waiting for message updates

### DIFF
--- a/ecdsa/resharing/round_1_old_step_1.go
+++ b/ecdsa/resharing/round_1_old_step_1.go
@@ -38,7 +38,6 @@ func (round *round1) Start() *tss.Error {
 	if !round.ReSharingParams().IsOldCommittee() {
 		return nil
 	}
-	round.allOldOK()
 
 	round.temp.ssidNonce = new(big.Int).SetUint64(uint64(0))
 	ssid, err := round.getSSID()

--- a/ecdsa/resharing/round_3_old_step_2.go
+++ b/ecdsa/resharing/round_3_old_step_2.go
@@ -24,7 +24,6 @@ func (round *round3) Start() *tss.Error {
 	if !round.ReSharingParams().IsOldCommittee() {
 		return nil
 	}
-	round.allOldOK()
 
 	Pi := round.PartyID()
 	i := Pi.Index

--- a/eddsa/resharing/round_1_old_step_1.go
+++ b/eddsa/resharing/round_1_old_step_1.go
@@ -37,7 +37,6 @@ func (round *round1) Start() *tss.Error {
 	if !round.ReSharingParams().IsOldCommittee() {
 		return nil
 	}
-	round.allOldOK()
 
 	Pi := round.PartyID()
 	i := Pi.Index

--- a/eddsa/resharing/round_3_old_step_2.go
+++ b/eddsa/resharing/round_3_old_step_2.go
@@ -24,7 +24,6 @@ func (round *round3) Start() *tss.Error {
 	if !round.ReSharingParams().IsOldCommittee() {
 		return nil
 	}
-	round.allOldOK()
 
 	Pi := round.PartyID()
 	i := Pi.Index


### PR DESCRIPTION
While implementing the resharing on two parties in a p2p architecture using the tss lib 2.0.2, old committee parties {0,1} is equal to new committee parties {0,1}, same threshold, we had an issue on `round 4` at the verification step on both parties:

`share from old committee did not pass Verify()` and `assertion failed: V_0 != y`

By running and looking inside each round and the messages that are broadcasted between parties (old and new), I found out that on `round 1` and `round 3` of resharing (worked on the ecdsa key), in the round's `Start()` the `allOldOK` is called and then considering all messages as already received by old parties at these two rounds. This makes the real execution of `round 3` to be skipped as the `Update()` is waiting for the messages (`dgRound1Messages` at `round 1` and `dgRound3Message1s` and `dgRound3Message2s` at `round 3`, and only then for each received message the associated `oldOk` party index should be set to true).

By adding the fix of this branch, the resharing is finalized on `round 5` and then completed on both parties. Could you please confirm this could be the fix for the verification errors at step 4.